### PR TITLE
Move overlap resolution to build time; add z field to schema

### DIFF
--- a/data/sticky_notes.json
+++ b/data/sticky_notes.json
@@ -3,400 +3,450 @@
     "id": "note_001",
     "text": "Onboarding flow feels confusing for new athletes",
     "x": 210,
-    "y": 185,
+    "y": -148,
     "author": "user_5",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_002",
     "text": "Profile setup is broken on Android",
-    "x": 225,
-    "y": 275,
+    "x": 185,
+    "y": 450,
     "author": "user_9",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_003",
     "text": "Sign-in throws a generic error after entering my email",
-    "x": 195,
-    "y": 200,
+    "x": 172,
+    "y": 125,
     "author": "user_2",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_004",
     "text": "Password reset email never lands in my inbox",
-    "x": 215,
-    "y": 260,
+    "x": 180,
+    "y": 206,
     "author": "user_9",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_005",
     "text": "Strava import keeps redirecting back to authorization",
     "x": 175,
-    "y": 130,
+    "y": -32,
     "author": "user_7",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_006",
     "text": "Verification code is rejected even when I type it correctly",
-    "x": 155,
-    "y": 220,
+    "x": 33,
+    "y": 284,
     "author": "user_1",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_007",
     "text": "App signs me out in the middle of a workout",
-    "x": 180,
-    "y": 160,
+    "x": 30,
+    "y": 124,
     "author": "user_3",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_008",
     "text": "Can't update my training goals — the save button does nothing",
-    "x": 250,
-    "y": 190,
+    "x": 335,
+    "y": -12,
     "author": "user_2",
-    "color": "orange"
+    "color": "orange",
+    "z": 0
   },
   {
     "id": "note_009",
     "text": "Account locks after a single wrong password attempt",
-    "x": 275,
-    "y": 250,
+    "x": 191,
+    "y": 360,
     "author": "user_10",
-    "color": "orange"
+    "color": "orange",
+    "z": 0
   },
   {
     "id": "note_010",
     "text": "Apple Health permissions prompt appears on every launch",
-    "x": 235,
-    "y": 130,
+    "x": 332,
+    "y": 118,
     "author": "user_9",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_011",
     "text": "Need richer export formats — TCX coverage is too limited",
-    "x": 750,
-    "y": 215,
+    "x": 796,
+    "y": 366,
     "author": "user_9",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_012",
     "text": "Exported summary image crops out the elevation chart",
-    "x": 735,
-    "y": 160,
+    "x": 826,
+    "y": -37,
     "author": "user_6",
-    "color": "blue"
+    "color": "blue",
+    "z": 0
   },
   {
     "id": "note_013",
     "text": "Can't export a specific lap — only the full activity",
-    "x": 695,
-    "y": 210,
+    "x": 509,
+    "y": 45,
     "author": "user_4",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_014",
     "text": "Activity export takes ages and sometimes never finishes",
-    "x": 800,
-    "y": 215,
+    "x": 951,
+    "y": 140,
     "author": "user_2",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_015",
     "text": "Activity privacy settings are confusing to configure",
-    "x": 690,
-    "y": 290,
+    "x": 664,
+    "y": 291,
     "author": "user_6",
-    "color": "blue"
+    "color": "blue",
+    "z": 0
   },
   {
     "id": "note_016",
     "text": "Shared route image looks blurry compared to the in-app map",
-    "x": 680,
-    "y": 245,
+    "x": 944,
+    "y": 295,
     "author": "user_5",
-    "color": "blue"
+    "color": "blue",
+    "z": 0
   },
   {
     "id": "note_017",
     "text": "Exported GPX file names are inconsistent and hard to track",
-    "x": 675,
-    "y": 205,
+    "x": 674,
+    "y": -23,
     "author": "user_4",
-    "color": "blue"
+    "color": "blue",
+    "z": 0
   },
   {
     "id": "note_018",
     "text": "No way to schedule weekly summary emails to my coach",
-    "x": 665,
-    "y": 230,
+    "x": 802,
+    "y": 258,
     "author": "user_9",
-    "color": "blue"
+    "color": "blue",
+    "z": 0
   },
   {
     "id": "note_019",
     "text": "Embedded workout widgets don't refresh after I edit an activity",
-    "x": 665,
-    "y": 135,
+    "x": 648,
+    "y": 133,
     "author": "user_1",
-    "color": "blue"
+    "color": "blue",
+    "z": 0
   },
   {
     "id": "note_020",
     "text": "Can't export kudos and comments along with the activity",
-    "x": 740,
-    "y": 140,
+    "x": 800,
+    "y": 96,
     "author": "user_7",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_021",
     "text": "Activity feed feels sluggish after a few years of runs",
-    "x": 345,
-    "y": 698,
+    "x": 464,
+    "y": 816,
     "author": "user_10",
-    "color": "purple"
+    "color": "purple",
+    "z": 0
   },
   {
     "id": "note_022",
     "text": "Map freezes for a few seconds when I zoom into a route",
-    "x": 250,
-    "y": 712,
+    "x": 255,
+    "y": 934,
     "author": "user_8",
-    "color": "pink"
+    "color": "pink",
+    "z": 0
   },
   {
     "id": "note_023",
     "text": "Pause button has a noticeable delay during a run",
-    "x": 240,
-    "y": 685,
+    "x": 87,
+    "y": 790,
     "author": "user_9",
-    "color": "purple"
+    "color": "purple",
+    "z": 0
   },
   {
     "id": "note_024",
     "text": "App crashes when I open a long ride history",
-    "x": 235,
-    "y": 595,
+    "x": 200,
+    "y": 618,
     "author": "user_10",
-    "color": "purple"
+    "color": "purple",
+    "z": 0
   },
   {
     "id": "note_025",
     "text": "Sync indicator spins forever but the workout doesn't upload",
-    "x": 135,
-    "y": 780,
+    "x": -49,
+    "y": 810,
     "author": "user_3",
-    "color": "purple"
+    "color": "purple",
+    "z": 0
   },
   {
     "id": "note_026",
     "text": "Searching past activities is painfully slow",
-    "x": 260,
-    "y": 660,
+    "x": 361,
+    "y": 803,
     "author": "user_2",
-    "color": "pink"
+    "color": "pink",
+    "z": 0
   },
   {
     "id": "note_027",
     "text": "Scrolling stutters on older Android phones",
-    "x": 180,
-    "y": 590,
+    "x": -63,
+    "y": 647,
     "author": "user_7",
-    "color": "pink"
+    "color": "pink",
+    "z": 0
   },
   {
     "id": "note_028",
     "text": "Battery drains quickly even when the app is in the background",
-    "x": 195,
-    "y": 700,
+    "x": 39,
+    "y": 492,
     "author": "user_8",
-    "color": "purple"
+    "color": "purple",
+    "z": 0
   },
   {
     "id": "note_029",
     "text": "Offline workouts get dropped when the phone reconnects",
-    "x": 340,
-    "y": 635,
+    "x": 212,
+    "y": 786,
     "author": "user_1",
-    "color": "pink"
+    "color": "pink",
+    "z": 0
   },
   {
     "id": "note_030",
     "text": "Random 'something went wrong' toasts appear with no detail",
-    "x": 215,
-    "y": 600,
+    "x": 94,
+    "y": 629,
     "author": "user_5",
-    "color": "purple"
+    "color": "purple",
+    "z": 0
   },
   {
     "id": "note_031",
     "text": "Hard to tell which friends are live during a group ride",
-    "x": 765,
-    "y": 705,
+    "x": 758,
+    "y": 958,
     "author": "user_8",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_032",
     "text": "Comments on activities get buried — there's no thread view",
-    "x": 820,
-    "y": 645,
+    "x": 947,
+    "y": 465,
     "author": "user_5",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_033",
     "text": "@mentions in comments don't notify the right user",
-    "x": 695,
-    "y": 670,
+    "x": 621,
+    "y": 793,
     "author": "user_5",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_034",
     "text": "Too many push notifications for minor kudos",
-    "x": 770,
-    "y": 740,
+    "x": 924,
+    "y": 902,
     "author": "user_9",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_035",
     "text": "No notification when someone replies to my comment",
-    "x": 675,
-    "y": 638,
+    "x": 666,
+    "y": 627,
     "author": "user_2",
-    "color": "blue"
+    "color": "blue",
+    "z": 0
   },
   {
     "id": "note_036",
     "text": "Live segment leaderboard pop-ups are distracting mid-run",
-    "x": 790,
-    "y": 608,
+    "x": 957,
+    "y": 599,
     "author": "user_5",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_037",
     "text": "Can't hand off the group ride leader role to another rider",
-    "x": 815,
-    "y": 710,
+    "x": 948,
+    "y": 762,
     "author": "user_2",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_038",
     "text": "Live tracking frequently drops for followers",
-    "x": 712,
-    "y": 580,
+    "x": 793,
+    "y": 530,
     "author": "user_9",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_039",
     "text": "Friends can't see new activities without refreshing the feed",
-    "x": 760,
-    "y": 712,
+    "x": 789,
+    "y": 672,
     "author": "user_9",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_040",
     "text": "Notification feed lacks context about why I was tagged",
-    "x": 712,
-    "y": 775,
+    "x": 765,
+    "y": 832,
     "author": "user_7",
-    "color": "yellow"
+    "color": "yellow",
+    "z": 0
   },
   {
     "id": "note_041",
     "text": "Hard to find the right workout template quickly",
-    "x": 540,
-    "y": 395,
+    "x": 503,
+    "y": 184,
     "author": "user_4",
-    "color": "orange"
+    "color": "orange",
+    "z": 0
   },
   {
     "id": "note_042",
     "text": "Workout template search results feel irrelevant",
-    "x": 405,
-    "y": 475,
+    "x": 496,
+    "y": 406,
     "author": "user_6",
-    "color": "orange"
+    "color": "orange",
+    "z": 0
   },
   {
     "id": "note_043",
     "text": "Can't organize routes into custom folders",
-    "x": 505,
-    "y": 400,
+    "x": 341,
+    "y": 263,
     "author": "user_4",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_044",
     "text": "Activity naming gets inconsistent across team members",
-    "x": 470,
-    "y": 435,
+    "x": 350,
+    "y": 651,
     "author": "user_9",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_045",
     "text": "No bulk rename for multiple activities",
-    "x": 455,
-    "y": 430,
+    "x": 496,
+    "y": 298,
     "author": "user_1",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_046",
     "text": "Activity tags are limited — I need finer categorization",
-    "x": 475,
-    "y": 438,
+    "x": 514,
+    "y": 666,
     "author": "user_6",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_047",
     "text": "Hard to keep consistent training zones across athletes",
-    "x": 420,
-    "y": 428,
+    "x": 349,
+    "y": 535,
     "author": "user_8",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_048",
     "text": "Duplicating a workout loses some of the custom intervals",
-    "x": 385,
-    "y": 412,
+    "x": 646,
+    "y": 455,
     "author": "user_10",
-    "color": "orange"
+    "color": "orange",
+    "z": 0
   },
   {
     "id": "note_049",
     "text": "Need better controls for organizing training plans by week",
-    "x": 465,
-    "y": 490,
+    "x": 342,
+    "y": 385,
     "author": "user_7",
-    "color": "green"
+    "color": "green",
+    "z": 0
   },
   {
     "id": "note_050",
     "text": "Can't lock a planned workout to prevent accidental changes",
-    "x": 525,
-    "y": 472,
+    "x": 502,
+    "y": 515,
     "author": "user_6",
-    "color": "orange"
+    "color": "orange",
+    "z": 0
   }
 ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vite --open /test.html",
-    "capture-gifs": "node scripts/capture-gifs.mjs"
+    "capture-gifs": "node scripts/capture-gifs.mjs",
+    "resolve-overlaps": "node scripts/resolve-overlaps.mjs"
   },
   "devDependencies": {
     "playwright": "^1.59.1",

--- a/scripts/resolve-overlaps.mjs
+++ b/scripts/resolve-overlaps.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Build-time overlap resolver for the sticky-notes dataset.
+ *
+ * Mirrors the runtime resolver previously in src/canvas-view.js. Bakes the
+ * resolved (x, y) into data/sticky_notes.json and ensures every note carries
+ * a `z` stacking-order field (default 0, raised by drag-to-front at runtime).
+ *
+ * Idempotent: re-running on already-resolved data is a no-op.
+ *
+ * Run:  node scripts/resolve-overlaps.mjs
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const NOTE_W      = 160;
+const NOTE_H      = 160;
+const GAP         = 8;
+const ITERS       = 60;
+const ORIGIN_PULL = 0.08;
+
+const here     = dirname(fileURLToPath(import.meta.url));
+const dataPath = resolve(here, '..', 'data', 'sticky_notes.json');
+
+function resolveOverlaps(notes) {
+  const pos    = notes.map((n) => ({ x: n.x, y: n.y }));
+  const origin = notes.map((n) => ({ x: n.x, y: n.y }));
+
+  for (let iter = 0; iter < ITERS; iter++) {
+    for (let i = 0; i < pos.length; i++) {
+      for (let j = i + 1; j < pos.length; j++) {
+        const dx       = pos[j].x - pos[i].x;
+        const dy       = pos[j].y - pos[i].y;
+        const overlapX = NOTE_W + GAP - Math.abs(dx);
+        const overlapY = NOTE_H + GAP - Math.abs(dy);
+
+        if (overlapX > 0 && overlapY > 0) {
+          if (overlapX < overlapY) {
+            const shift = overlapX / 2;
+            pos[i].x -= dx > 0 ? shift : -shift;
+            pos[j].x += dx > 0 ? shift : -shift;
+          } else {
+            const shift = overlapY / 2;
+            pos[i].y -= dy > 0 ? shift : -shift;
+            pos[j].y += dy > 0 ? shift : -shift;
+          }
+        }
+      }
+
+      pos[i].x += (origin[i].x - pos[i].x) * ORIGIN_PULL;
+      pos[i].y += (origin[i].y - pos[i].y) * ORIGIN_PULL;
+    }
+  }
+
+  return pos;
+}
+
+const raw    = await readFile(dataPath, 'utf8');
+const notes  = JSON.parse(raw);
+const before = notes.map((n) => ({ x: n.x, y: n.y }));
+const pos    = resolveOverlaps(notes);
+
+let moved   = 0;
+let maxDrift = 0;
+const next = notes.map((n, i) => {
+  const x = Math.round(pos[i].x);
+  const y = Math.round(pos[i].y);
+  const drift = Math.hypot(x - before[i].x, y - before[i].y);
+  if (drift > 0) moved++;
+  if (drift > maxDrift) maxDrift = drift;
+  return { ...n, x, y, z: typeof n.z === 'number' ? n.z : 0 };
+});
+
+await writeFile(dataPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+
+console.log(`resolved ${notes.length} notes`);
+console.log(`  moved:     ${moved}`);
+console.log(`  max drift: ${maxDrift.toFixed(1)} px`);
+console.log(`  z field:   ensured (default 0)`);
+console.log(`  wrote:     ${dataPath}`);

--- a/src/canvas-view.js
+++ b/src/canvas-view.js
@@ -1,8 +1,8 @@
 /**
- * canvas-view.js — SVG canvas rendering notes at their original x/y positions.
+ * canvas-view.js — SVG canvas rendering notes at their persisted x/y positions.
  *
- * Notes are rendered as square sticky cards at the coordinates from the JSON.
- * Overlapping notes are pushed apart while staying near their original position.
+ * Notes render at the coordinates carried in the JSON. Overlap resolution is a
+ * build-time step (scripts/resolve-overlaps.mjs); the runtime trusts the data.
  * After clustering, a cluster-color border + dot identifies each group.
  * Hover reveals the author name.
  */
@@ -11,7 +11,6 @@ import * as d3 from 'd3';
 
 const NOTE_W  = 160;
 const NOTE_H  = 160; // square stickies
-const GAP     = 8;   // minimum gap between notes after collision resolution
 const PADDING = 72;  // canvas padding around the note extent
 
 // Sticky-note paper palette (pastel fills tuned for ≥4.5:1 text contrast)
@@ -78,52 +77,6 @@ export function clusterColor(idx) {
 }
 
 /**
- * Resolves overlapping notes by iteratively pushing them apart.
- * Each note is treated as an axis-aligned rectangle (NOTE_W × NOTE_H).
- * A soft pull back toward the original position preserves spatial intent.
- *
- * @param {Array<{x: number, y: number}>} notes
- * @returns {Array<{x: number, y: number}>} resolved positions (same order)
- */
-function resolveOverlaps(notes) {
-  const ITERS       = 60;
-  const ORIGIN_PULL = 0.08; // how strongly each note is pulled back to its origin
-
-  const pos    = notes.map((n) => ({ x: n.x, y: n.y }));
-  const origin = notes.map((n) => ({ x: n.x, y: n.y }));
-
-  for (let iter = 0; iter < ITERS; iter++) {
-    for (let i = 0; i < pos.length; i++) {
-      for (let j = i + 1; j < pos.length; j++) {
-        const dx       = pos[j].x - pos[i].x;
-        const dy       = pos[j].y - pos[i].y;
-        const overlapX = NOTE_W + GAP - Math.abs(dx);
-        const overlapY = NOTE_H + GAP - Math.abs(dy);
-
-        if (overlapX > 0 && overlapY > 0) {
-          // Push apart along the axis of least penetration
-          if (overlapX < overlapY) {
-            const shift = overlapX / 2;
-            pos[i].x -= dx > 0 ? shift : -shift;
-            pos[j].x += dx > 0 ? shift : -shift;
-          } else {
-            const shift = overlapY / 2;
-            pos[i].y -= dy > 0 ? shift : -shift;
-            pos[j].y += dy > 0 ? shift : -shift;
-          }
-        }
-      }
-
-      // Gently pull back toward original position
-      pos[i].x += (origin[i].x - pos[i].x) * ORIGIN_PULL;
-      pos[i].y += (origin[i].y - pos[i].y) * ORIGIN_PULL;
-    }
-  }
-
-  return pos;
-}
-
-/**
  * Expands a convex hull polygon outward from its centroid by `pad` pixels.
  * Used to give cluster hulls breathing room beyond the note rectangle edges.
  *
@@ -151,7 +104,7 @@ export function expandHull(hull, pad) {
  * @param {string[]|null} labels       cluster label per cluster index
  */
 export function renderCanvas(container, notes, assignments = null, labels = null) {
-  const pos = resolveOverlaps(notes);
+  const pos = notes.map((n) => ({ x: n.x, y: n.y }));
 
   const xs   = pos.map((p) => p.x);
   const ys   = pos.map((p) => p.y);

--- a/src/loader.js
+++ b/src/loader.js
@@ -28,6 +28,9 @@ function validateNote(note, index) {
   if (typeof note.x !== 'number' || typeof note.y !== 'number') {
     return `Note at index ${index} has non-numeric x/y coordinates`;
   }
+  if ('z' in note && typeof note.z !== 'number') {
+    return `Note at index ${index} has non-numeric "z"`;
+  }
   return null;
 }
 
@@ -58,5 +61,5 @@ export async function loadNotes(url) {
     throw new Error(`Schema validation failed:\n${errors.join('\n')}`);
   }
 
-  return data;
+  return data.map((n) => ({ ...n, z: typeof n.z === 'number' ? n.z : 0 }));
 }


### PR DESCRIPTION
Step 1 of [#3](https://github.com/vmorais17/local-semantics-canvas/issues/3) (drag-and-drop with FSA persistence), which expands the AC of [#1](https://github.com/vmorais17/local-semantics-canvas/issues/1).

## Why

`resolveOverlaps()` ran on every render and silently rewrote positions in a local array. Once drag-and-drop lands, that would clobber user-placed coordinates on the very next render. Moving it to a one-shot build step makes the JSON the single source of truth — exactly what the upcoming FSA-backed persistence needs.

## What changed

- **`scripts/resolve-overlaps.mjs`** (new) — node ESM, mirrors the runtime resolver. Reads `data/sticky_notes.json`, writes resolved coords + `z` field back. Idempotent. Wired up as `npm run resolve-overlaps`.
- **`data/sticky_notes.json`** — ran the script once. All 50 notes had positions adjusted (max drift 333 px — the seed data was heavily overlapping). Every note now carries `z: 0`.
- **`src/loader.js`** — validates `z` when present; defaults to `0` on the way out so downstream code can trust the field exists.
- **`src/canvas-view.js`** — `resolveOverlaps` function and runtime call removed. The render now trusts the JSON. Unused `GAP` constant removed; header comment updated to reflect the new contract.

## Reviewer notes

- The runtime swap is mathematically equivalent: the JSON now contains the literal output of the same algorithm that used to run per-render. Visual output should be identical.
- `z` field intent: stacking order. Drag-to-front in step 4 will assign `z = max(z) + 1` on `dragstart`. Default 0 is fine for everything pre-drag.
- `data/sticky_notes.json` ships as a starter board. Step 3 (boot flow) will prompt the user to save a copy to their own iCloud-synced folder; that file becomes the working board.
- Negative coords appear in the JSON (`y: -148`) — fine, the SVG offset (`translate(PADDING - minX, ...)`) handles it.

## Test plan

- [x] `npm run resolve-overlaps` is idempotent (re-running produces no further drift)
- [x] `npm run build` succeeds
- [x] Dev server serves index (200) and JSON (200); all 50 notes load with `z` field
- [ ] Open in Brave, confirm canvas renders identically to pre-change layout
- [ ] Run \"Find Themes\" — verify clustering still produces hulls correctly with the new positions

## Out of scope

Drag-and-drop, the `board-fs.js` module, the boot flow, and persistence are all separate steps tracked in [#3](https://github.com/vmorais17/local-semantics-canvas/issues/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)