### PR TITLE
Wire board-fs into boot flow: pick / open / create / continue

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,32 @@
         </div>
       </section>
 
-      <!-- Canvas view (default) -->
-      <section id="canvas-view" class="view">
+      <!-- Board picker (shown until a board is opened) -->
+      <section id="board-picker" class="board-picker">
+        <div class="board-picker-card">
+          <h2 class="board-picker-title">Pick a board</h2>
+          <p class="board-picker-subtitle">
+            Each board is a JSON file on your disk. Save it in your iCloud Drive folder to sync across devices.
+          </p>
+
+          <div class="board-picker-actions">
+            <button id="btn-continue" class="btn-primary hidden" type="button">
+              Continue: <span id="continue-name"></span>
+            </button>
+            <button id="btn-open" class="btn-secondary" type="button">Open existing board…</button>
+            <button id="btn-create" class="btn-secondary" type="button">Create new board…</button>
+          </div>
+
+          <p id="board-picker-error" class="board-picker-error hidden" role="alert"></p>
+          <p id="board-picker-unsupported" class="board-picker-unsupported hidden">
+            Your browser doesn't support the File System Access API.
+            Please use a Chromium-based browser (Chrome, Edge, Brave, or Opera).
+          </p>
+        </div>
+      </section>
+
+      <!-- Canvas view (hidden until board picked) -->
+      <section id="canvas-view" class="view hidden">
         <div id="canvas-container"></div>
       </section>
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -35,20 +35,15 @@ function validateNote(note, index) {
 }
 
 /**
- * Loads and validates the sticky notes JSON from the given URL.
- * @param {string} url
- * @returns {Promise<Array>} validated array of note objects
+ * Validates an already-parsed value against the sticky notes schema and
+ * returns the normalised array (with `z` defaulted to 0). Throws on any
+ * validation failure. Used both by loadNotes (URL fetch) and by the FSA
+ * board picker, which receives parsed JSON directly from disk.
+ *
+ * @param {unknown} data
+ * @returns {Array} validated, z-defaulted notes
  */
-export async function loadNotes(url) {
-  let data;
-  try {
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-    data = await res.json();
-  } catch (err) {
-    throw new Error(`Failed to load sticky notes: ${err.message}`);
-  }
-
+export function validateNotes(data) {
   if (!Array.isArray(data)) {
     throw new Error('Sticky notes JSON must be a top-level array');
   }
@@ -62,4 +57,21 @@ export async function loadNotes(url) {
   }
 
   return data.map((n) => ({ ...n, z: typeof n.z === 'number' ? n.z : 0 }));
+}
+
+/**
+ * Loads and validates the sticky notes JSON from the given URL.
+ * @param {string} url
+ * @returns {Promise<Array>} validated array of note objects
+ */
+export async function loadNotes(url) {
+  let data;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+    data = await res.json();
+  } catch (err) {
+    throw new Error(`Failed to load sticky notes: ${err.message}`);
+  }
+  return validateNotes(data);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,19 @@
 /**
  * main.js — Application entry point.
- * Wires together: data loading → canvas render → clustering → both views.
+ * Wires together: board picker → canvas render → clustering → both views.
+ *
+ * Privacy: note content stays in the browser. With FSA persistence, it also
+ * stays on the user's local disk inside whichever folder they chose; nothing
+ * is uploaded by this app, and any cross-device sync is delegated entirely
+ * to the user's OS-level cloud-drive client.
  */
 
-import { loadNotes } from './loader.js';
+import { loadNotes, validateNotes } from './loader.js';
+import {
+  isSupported as fsSupported,
+  openBoard, createBoard, readBoard,
+  listRecentBoards, forgetBoard,
+} from './board-fs.js';
 import { clusterNotes } from './pipeline.js';
 import { renderCanvas } from './canvas-view.js';
 import { renderClusterView } from './cluster-view.js';
@@ -29,6 +39,14 @@ const progressBar     = document.getElementById('progress-bar');
 const progressLabel   = document.getElementById('progress-label');
 const progressDetail  = document.getElementById('progress-detail');
 
+const boardPicker            = document.getElementById('board-picker');
+const btnContinue            = document.getElementById('btn-continue');
+const continueName           = document.getElementById('continue-name');
+const btnOpen                = document.getElementById('btn-open');
+const btnCreate              = document.getElementById('btn-create');
+const boardPickerError       = document.getElementById('board-picker-error');
+const boardPickerUnsupported = document.getElementById('board-picker-unsupported');
+
 // ─── App state ───────────────────────────────────────────────────
 // Module-scope so showView() can pass current values to renderSemanticView
 // regardless of when the Semantics tab is activated relative to clustering.
@@ -37,6 +55,7 @@ let embeddingsReduced = [];
 let assignments       = [];
 let clusters          = [];
 let clusterViewApi    = null;
+let currentBoard      = null; // { id, handle, name } once a board is opened
 
 // ─── Progress helpers ────────────────────────────────────────────
 function showProgress(label = '', pct = 0) {
@@ -152,18 +171,101 @@ btnClusterAction.addEventListener('click', async () => {
   }
 });
 
-// ─── Initial load: fetch notes and render canvas immediately ──────
-async function init() {
+// ─── Board picker ─────────────────────────────────────────────────
+function showPickerError(msg) {
+  boardPickerError.textContent = msg;
+  boardPickerError.classList.remove('hidden');
+}
+
+function clearPickerError() {
+  boardPickerError.textContent = '';
+  boardPickerError.classList.add('hidden');
+}
+
+// Loads validated notes into app state and reveals the canvas.
+// Caller has already confirmed read access; data is the parsed JSON contents.
+async function loadBoard({ id, handle, data, name }) {
+  let validated;
   try {
-    notes = await loadNotes('/data/sticky_notes.json');
-    renderCanvas(canvasContainer, notes);
+    validated = validateNotes(data);
   } catch (err) {
-    console.error('Failed to load notes:', err);
-    canvasContainer.innerHTML = `
-      <p style="padding:24px;color:#e11d48;font-size:14px;">
-        Error loading sticky notes: ${err.message}
-      </p>`;
+    // Bad schema — drop the recents entry so we don't keep offering it.
+    if (id) await forgetBoard(id);
+    showPickerError(`Couldn't load that board: ${err.message}`);
+    return;
+  }
+  notes        = validated;
+  currentBoard = { id, handle, name };
+  boardPicker.classList.add('hidden');
+  canvasView.classList.remove('hidden');
+  btnClusterAction.disabled = false;
+  renderCanvas(canvasContainer, notes);
+}
+
+async function handleContinue(record) {
+  clearPickerError();
+  try {
+    const data = await readBoard(record.handle); // ensurePermission inside
+    await loadBoard({ id: record.id, handle: record.handle, data, name: record.name });
+  } catch (err) {
+    if (err.name === 'NotAllowedError') {
+      showPickerError('Permission was denied. Pick another board?');
+      return;
+    }
+    if (err.name === 'NotFoundError') {
+      await forgetBoard(record.id);
+      btnContinue.classList.add('hidden');
+      showPickerError(`"${record.name}" wasn't found on disk and was removed from recents.`);
+      return;
+    }
+    showPickerError(`Couldn't open "${record.name}": ${err.message}`);
   }
 }
 
-init();
+async function handleOpen() {
+  clearPickerError();
+  try {
+    const result = await openBoard();
+    await loadBoard({ ...result, name: result.handle.name });
+  } catch (err) {
+    if (err.name === 'AbortError') return; // user cancelled the picker
+    showPickerError(`Couldn't open board: ${err.message}`);
+  }
+}
+
+async function handleCreate() {
+  clearPickerError();
+  try {
+    // Seed from the bundled starter dataset (already validated by loadNotes).
+    const starter = await loadNotes('/data/sticky_notes.json');
+    const result  = await createBoard(starter, 'sticky-notes.json');
+    await loadBoard({ ...result, name: result.handle.name });
+  } catch (err) {
+    if (err.name === 'AbortError') return;
+    showPickerError(`Couldn't create board: ${err.message}`);
+  }
+}
+
+btnOpen.addEventListener('click', handleOpen);
+btnCreate.addEventListener('click', handleCreate);
+
+async function setupPicker() {
+  btnClusterAction.disabled = true;
+
+  if (!fsSupported) {
+    boardPickerUnsupported.classList.remove('hidden');
+    btnOpen.disabled   = true;
+    btnCreate.disabled = true;
+    return;
+  }
+
+  const recents = await listRecentBoards();
+  if (recents.length > 0) {
+    const last = recents[0];
+    continueName.textContent = last.name;
+    btnContinue.classList.remove('hidden');
+    btnContinue.onclick = () => handleContinue(last);
+  }
+}
+
+setupPicker();

--- a/src/styles.css
+++ b/src/styles.css
@@ -181,6 +181,23 @@ body {
 .btn-primary:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
+.btn-secondary {
+  padding: 7px 18px;
+  background: white;
+  color: var(--color-text);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.btn-secondary:hover:not(:disabled) { border-color: var(--color-text-muted); background: var(--color-bg); }
+.btn-secondary:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
+
 /* ─── Main area ────────────────────────────────────────────────── */
 .app-main {
   flex: 1;
@@ -771,6 +788,75 @@ body {
   color: var(--color-text-muted); /* #6b6b6b — replaces #e0e0da (~1.2:1 fail) */
   padding: 0 4px;
   font-weight: 400;
+}
+
+/* ─── Board picker ─────────────────────────────────────────────── */
+.board-picker {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(245, 245, 240, 0.92);
+  z-index: 25;
+  padding: 24px;
+}
+
+.board-picker-card {
+  width: 100%;
+  max-width: 440px;
+  background: white;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 28px 28px 24px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.board-picker-title {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+}
+
+.board-picker-subtitle {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--color-text-muted);
+}
+
+.board-picker-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.board-picker-actions button {
+  width: 100%;
+  padding: 10px 16px;
+  font-size: 13px;
+}
+
+.board-picker-error {
+  font-size: 13px;
+  color: #b91c1c;       /* 5.9:1 on white — WCAG AA */
+  padding: 10px 12px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+}
+
+.board-picker-unsupported {
+  font-size: 13px;
+  color: #92400e;       /* 7.0:1 on white — WCAG AA */
+  padding: 10px 12px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  line-height: 1.5;
 }
 
 /* ─── Reduced motion ────────────────────────────────────────────── */


### PR DESCRIPTION
**Stacked on [#5](https://github.com/vmorais17/local-semantics-canvas/pull/5) → [#4](https://github.com/vmorais17/local-semantics-canvas/pull/4).** Step 3 of [#3](https://github.com/vmorais17/local-semantics-canvas/issues/3). Merge order: #4 → #5 → this. Each rebase as it goes.

## Why

PR #5 added the `board-fs` module but didn't wire it in. This PR replaces the app's auto-fetch on init with a real board picker so the user explicitly chooses where their data lives — the JSON file on disk becomes the single source of truth. That's the architectural foundation for step 4 (drag-and-drop persistence) and the long-term MCP-readable file model.

## What changed

**`src/loader.js`** — extracted `validateNotes(data)` so the boot path can validate parsed JSON returned by `board-fs` without round-tripping through `fetch()`. `loadNotes(url)` now thin-wraps `fetch + validateNotes`.

**`index.html`** — new `<section id=\"board-picker\">` overlay with three actions: *Continue: <name>*, *Open existing…*, *Create new…*, plus an error region and an unsupported-browser banner. Canvas view starts hidden.

**`src/styles.css`** — picker styling: full-overlay backdrop, centered card, error/unsupported banners (WCAG-AA contrast). Adds a `.btn-secondary` outlined-button variant for the picker actions.

**`src/main.js`** — replaces `init()` with `setupPicker()`. Handlers:
- `handleContinue(record)` — `readBoard(record.handle)` (permission requested inside, on the click gesture). On `NotFoundError`, prunes the stale record and informs the user. On `NotAllowedError`, prompts for re-pick.
- `handleOpen()` — `openBoard()`. `AbortError` (user cancelled) is silent.
- `handleCreate()` — fetches the bundled starter dataset, calls `createBoard(starter, 'sticky-notes.json')`. User picks any location; iCloud Drive is the intended target.
- `loadBoard()` — single integration point: validates → sets state → hides picker → renders canvas → enables \"Find Themes\".

\"Find Themes\" is disabled until a board is loaded.

`currentBoard = { id, handle, name }` is now app state — step 4's drag persistence reads this to know where to write.

## Reviewer notes

- **No fallback for non-Chromium browsers.** Firefox/Safari users see the warning banner; the buttons are disabled. This is intentional — drag-and-drop without persistence is the anti-feature, and degraded read-only mode would muddy the v1 contract. Adding it later is straightforward.
- **`writeBoard` is intentionally NOT imported here.** It lands with step 4 (drag-end → write). Importing it now would be dead code.
- **Bad-schema cleanup**: if `validateNotes` throws after a successful read, we call `forgetBoard(id)` so a malformed file doesn't keep showing up under \"Continue.\"
- **Privacy comment** added at the top of main.js naming the FSA-strengthened privacy model explicitly (per CLAUDE.md L0 kernel).

## Test plan

- [x] `npm run build` — full tree compiles
- [x] Dev server serves the picker markup and CSS class names
- [ ] Manual in Brave (Chromium): picker shows on cold load; *Create new…* prompts for save location; chosen file gets the starter JSON and the canvas renders
- [ ] Manual: reload — *Continue: <name>* appears; clicking re-prompts for permission and reopens the file
- [ ] Manual: pick a non-JSON file via *Open existing…* — error surfaces in the picker, recents stays clean
- [ ] Manual: cancel both pickers — picker remains, no error toast
- [ ] Manual on iCloud Drive: pick a file inside `~/Library/Mobile Documents/com~apple~CloudDocs/...`. Verify read works (note the cold-stub download caveat in #3)

## Out of scope (still)

Drag-and-drop and the `writeBoard` wiring → step 4. Cross-tab sync, conflict-detection UI, encryption → deferred per #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)