### PR TITLE
Drag-and-drop notes; persist x/y/z to disk via writeBoard

### DIFF
--- a/src/canvas-view.js
+++ b/src/canvas-view.js
@@ -102,8 +102,12 @@ export function expandHull(hull, pad) {
  * @param {Array} notes                raw note objects
  * @param {number[]|null} assignments  cluster index per note, or null if not yet clustered
  * @param {string[]|null} labels       cluster label per cluster index
+ * @param {{ onDragEnd?: (id: string, coords: {x:number, y:number, z:number}) => void }} [options]
+ *        If `onDragEnd` is provided, notes become draggable; the callback fires
+ *        on each drag-release with the new integer coords and incremented z.
  */
-export function renderCanvas(container, notes, assignments = null, labels = null) {
+export function renderCanvas(container, notes, assignments = null, labels = null, options = {}) {
+  const { onDragEnd } = options;
   const pos = notes.map((n) => ({ x: n.x, y: n.y }));
 
   const xs   = pos.map((p) => p.x);
@@ -254,6 +258,47 @@ export function renderCanvas(container, notes, assignments = null, labels = null
       .attr('fill', (_, i) => clusterColor(assignments[i]))
       .attr('stroke', 'white')
       .attr('stroke-width', 1.5);
+  }
+
+  // ── Z-stack ordering & drag ──────────────────────────────────────────────────
+  // Reorder note groups by z so a higher z paints on top of lower-z siblings.
+  // The data array order is unchanged — assignments[i] still aligns with notes[i].
+  noteGroups.sort((a, b) => a.z - b.z);
+
+  if (typeof onDragEnd === 'function') {
+    let didMove = false;
+
+    const drag = d3.drag()
+      .on('start', function () {
+        didMove = false;
+        d3.select(this).raise().style('cursor', 'grabbing');
+        // Hide hulls during drag, regardless of toggle state.
+        // .hull-layer may not exist yet (no clustering) — selection is empty, no-op.
+        g.select('.hull-layer').style('opacity', 0);
+      })
+      .on('drag', function (event, d) {
+        didMove = true;
+        const i = notes.indexOf(d);
+        pos[i].x += event.dx;
+        pos[i].y += event.dy;
+        d3.select(this).attr('transform', `translate(${pos[i].x}, ${pos[i].y})`);
+      })
+      .on('end', function (_, d) {
+        d3.select(this).style('cursor', 'grab');
+        // Clear the inline opacity override so the CSS toggle state takes back over.
+        g.select('.hull-layer').style('opacity', null);
+        if (!didMove) return; // pure click without movement — no z bump, no save
+        const i    = notes.indexOf(d);
+        const maxZ = notes.reduce((m, n) => (n.z > m ? n.z : m), 0);
+        d.z = maxZ + 1;
+        onDragEnd(d.id, {
+          x: Math.round(pos[i].x),
+          y: Math.round(pos[i].y),
+          z: d.z,
+        });
+      });
+
+    noteGroups.style('cursor', 'grab').call(drag);
   }
 
   // ── Cluster convex hulls ─────────────────────────────────────────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@
 import { loadNotes, validateNotes } from './loader.js';
 import {
   isSupported as fsSupported,
-  openBoard, createBoard, readBoard,
+  openBoard, createBoard, readBoard, writeBoard,
   listRecentBoards, forgetBoard,
 } from './board-fs.js';
 import { clusterNotes } from './pipeline.js';
@@ -56,6 +56,8 @@ let assignments       = [];
 let clusters          = [];
 let clusterViewApi    = null;
 let currentBoard      = null; // { id, handle, name } once a board is opened
+let noteIdToIdx       = new Map(); // rebuilt whenever `notes` is replaced
+let saveTimer         = null;      // debounce handle for writeBoard
 
 // ─── Progress helpers ────────────────────────────────────────────
 function showProgress(label = '', pct = 0) {
@@ -104,6 +106,46 @@ function applyHullVisibility() {
 
 hullToggle.addEventListener('change', applyHullVisibility);
 
+// ─── Drag persistence ─────────────────────────────────────────────
+// Drag updates happen in canvas-view; this module owns the file save.
+// Saves are debounced so a flurry of quick re-positions coalesces into
+// one write per "settle." 300 ms is imperceptible after a mouse-up but
+// long enough that successive drags batch.
+
+const SAVE_DEBOUNCE_MS = 300;
+
+function scheduleSave() {
+  if (!currentBoard) return;
+  clearTimeout(saveTimer);
+  saveTimer = setTimeout(async () => {
+    try {
+      await writeBoard(currentBoard.handle, notes);
+    } catch (err) {
+      // Soft-fail: the user's UI state is the truth in memory; next
+      // interaction will re-prompt for permission if it was revoked.
+      console.error('Save failed:', err);
+    }
+  }, SAVE_DEBOUNCE_MS);
+}
+
+function handleNoteDragEnd(id, { x, y, z }) {
+  const i = noteIdToIdx.get(id);
+  if (i === undefined) return;
+  notes[i].x = x;
+  notes[i].y = y;
+  notes[i].z = z;
+
+  // If hulls are present (post-clustering), recompute by re-rendering.
+  // Without clusters, the in-place transform is already correct — no re-render.
+  if (assignments.length > 0) {
+    const labels = clusters.map((c) => c.label);
+    renderCanvas(canvasContainer, notes, assignments, labels, { onDragEnd: handleNoteDragEnd });
+    applyHullVisibility();
+  }
+
+  scheduleSave();
+}
+
 // ─── Cluster action ───────────────────────────────────────────────
 btnClusterAction.addEventListener('click', async () => {
   if (notes.length === 0) return;
@@ -151,7 +193,7 @@ btnClusterAction.addEventListener('click', async () => {
 
     hideProgress();
 
-    renderCanvas(canvasContainer, notes, assignments, labels);
+    renderCanvas(canvasContainer, notes, assignments, labels, { onDragEnd: handleNoteDragEnd });
     clusterViewApi = renderClusterView(clusterContainer, notes, assignments, clusters);
 
     // Apply hull visibility immediately after render — hull-layer starts hidden
@@ -195,11 +237,12 @@ async function loadBoard({ id, handle, data, name }) {
     return;
   }
   notes        = validated;
+  noteIdToIdx  = new Map(notes.map((n, i) => [n.id, i]));
   currentBoard = { id, handle, name };
   boardPicker.classList.add('hidden');
   canvasView.classList.remove('hidden');
   btnClusterAction.disabled = false;
-  renderCanvas(canvasContainer, notes);
+  renderCanvas(canvasContainer, notes, null, null, { onDragEnd: handleNoteDragEnd });
 }
 
 async function handleContinue(record) {


### PR DESCRIPTION
**Stacked on [#6](https://github.com/vmorais17/local-semantics-canvas/pull/6) → [#5](https://github.com/vmorais17/local-semantics-canvas/pull/5) → [#4](https://github.com/vmorais17/local-semantics-canvas/pull/4).** Step 4 — final step — of [#3](https://github.com/vmorais17/local-semantics-canvas/issues/3). With this merged, the AC of [#1](https://github.com/vmorais17/local-semantics-canvas/issues/1) is satisfied.

## Why

This is the user-facing payoff: notes are draggable, and their positions persist back to the JSON file the user picked at boot. The previous three PRs put the foundations in place; this one is just the connection.

## What changed

**`src/canvas-view.js`**
- New optional `options.onDragEnd` parameter on `renderCanvas`. Notes become draggable only when this callback is provided.
- Z-stack ordering: after `noteGroups` are bound, `.sort((a, b) => a.z - b.z)` reorders DOM siblings by z. Data-array order is unchanged, so `assignments[i]` still aligns with `notes[i]`.
- `d3.drag()` handler:
  - `start`: `.raise()` on the dragged group (paints on top), set cursor to `grabbing`, hide `.hull-layer` via inline `opacity: 0`.
  - `drag`: increment local `pos[i]`, update the SVG transform.
  - `end`: clear inline opacity (CSS toggle state takes back over), reset cursor; if movement actually occurred, bump `d.z = max(z) + 1` and emit `onDragEnd(id, {x, y, z})` with rounded ints.
- Pure click without movement = no-op. No z bump, no callback.

**`src/main.js`**
- Re-imports `writeBoard` (was deferred from #6).
- Adds `noteIdToIdx` map (rebuilt on every `loadBoard`) and a `saveTimer` for debounce.
- `handleNoteDragEnd(id, coords)` updates `notes[i].{x,y,z}`, calls `scheduleSave()`, and re-renders the canvas if clusters are present so hulls recompute around the new position.
- `scheduleSave()` debounces `writeBoard(currentBoard.handle, notes)` at **300 ms** — long enough to coalesce successive drag-ends into one write, short enough to feel "saved" if the user looks immediately.
- Both `renderCanvas` call sites pass `{ onDragEnd: handleNoteDragEnd }`.

## Reviewer notes

- **Re-render on dragend only when clusters exist.** Without hulls, the in-place transform during drag is already the truth — no need to rebuild the SVG. Saves a few ms per drag in the common pre-clustering case.
- **Soft-fail on save errors.** If `writeBoard` throws (permission revoked, file moved), we `console.error` and let the user's next gesture re-prompt rather than blocking the UI. The in-memory state is the truth for the session; the file catches up on the next successful save.
- **300 ms debounce.** Picked deliberately — longer than human reaction time (~250 ms) so users don't perceive lag, shorter than the cognitive "I'm done arranging" pause (~500 ms+) so a flurry of drags settles to one write.
- **No bounds clamping.** Notes can go off-canvas; the SVG dynamic sizing accommodates on next render. Negative coords are already supported (verified in step 1's resolved dataset).
- **No keyboard alternative.** That's an accessibility gap; tracked separately as future work, not a blocker for this AC.

## Test plan

- [x] `npm run build` — full tree compiles
- [x] Syntax checks on `canvas-view.js` and `main.js`
- [ ] Manual in Brave: pick a board → drag a note → release → close tab → reopen → *Continue: <name>* → note is at the dragged position with z bumped
- [ ] Manual: drag note A, then drag note B without releasing for long — single save fires after the last release
- [ ] Manual: cluster notes (Find Themes), drag a note out of its hull — hull recomputes around the new position after release
- [ ] Manual: click a note without moving (mousedown + mouseup, no drag) — no save, no z change
- [ ] Manual: drag while hovering — author label and tooltip behavior is not broken
- [ ] Manual on iCloud Drive: drag, then check the file on disk reflects the new coordinates within ~300 ms

## What this completes

With #4 → #5 → #6 → this merged:
- `data/sticky_notes.json` shipped with resolved positions + z field
- Reusable `board-fs.js` module
- Boot picker (Open / Create / Continue)
- **Drag-and-drop with FSA-backed persistence in a user-chosen file**

The MCP-readable file foundation is now real: any external process (future MCP server, manual edit, scripts) can read or write the same JSON the browser writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)