### PR TITLE
Canvas editing: rename, recolor, add, delete sticky notes

### DIFF
--- a/src/canvas-view.js
+++ b/src/canvas-view.js
@@ -4,7 +4,13 @@
  * Notes render at the coordinates carried in the JSON. Overlap resolution is a
  * build-time step (scripts/resolve-overlaps.mjs); the runtime trusts the data.
  * After clustering, a cluster-color border + dot identifies each group.
- * Hover reveals the author name.
+ *
+ * Editing affordances (all opt-in via callbacks on renderCanvas options):
+ *   • Hover a note → top-left toolbar with [color] [×]
+ *   • Click [color] → swatches replace the toolbar inline; pick to recolor
+ *   • Click [×] → delete
+ *   • Double-click text → edit; Enter or blur commits, Esc reverts
+ *   • Double-click empty canvas → create note at click position
  */
 
 import * as d3 from 'd3';
@@ -102,12 +108,29 @@ export function expandHull(hull, pad) {
  * @param {Array} notes                raw note objects
  * @param {number[]|null} assignments  cluster index per note, or null if not yet clustered
  * @param {string[]|null} labels       cluster label per cluster index
- * @param {{ onDragEnd?: (id: string, coords: {x:number, y:number, z:number}) => void }} [options]
- *        If `onDragEnd` is provided, notes become draggable; the callback fires
- *        on each drag-release with the new integer coords and incremented z.
+ * @param {object} [options]
+ * @param {(id: string, coords: {x:number, y:number, z:number}) => void} [options.onDragEnd]
+ *        Notes become draggable; fires on each drag-release with new int coords + bumped z.
+ * @param {(id: string, newText: string) => void} [options.onNoteEdit]
+ *        Notes get a dblclick-to-edit affordance; fires on commit (blur / Enter).
+ * @param {(id: string) => void} [options.onNoteDelete]
+ *        Hover toolbar shows × button; fires on click.
+ * @param {(id: string, color: string) => void} [options.onNoteColorChange]
+ *        Hover toolbar shows palette button; fires on swatch click.
+ * @param {(coords: {x:number, y:number}) => void} [options.onNoteCreate]
+ *        Double-click on empty canvas fires this with the local SVG coords.
+ * @param {string} [options.autoEditNoteId]
+ *        After rendering, enter edit mode for the note with this id (used after create).
  */
 export function renderCanvas(container, notes, assignments = null, labels = null, options = {}) {
-  const { onDragEnd } = options;
+  const {
+    onDragEnd,
+    onNoteEdit,
+    onNoteDelete,
+    onNoteColorChange,
+    onNoteCreate,
+    autoEditNoteId,
+  } = options;
   const pos = notes.map((n) => ({ x: n.x, y: n.y }));
 
   const xs   = pos.map((p) => p.x);
@@ -159,7 +182,9 @@ export function renderCanvas(container, notes, assignments = null, labels = null
     .attr('stroke', (_, i) => assignments ? clusterColor(assignments[i]) : 'none')
     .attr('stroke-width', 2.5);
 
-  // Note text — centered vertically and horizontally within the sticky
+  // Note text — centered vertically and horizontally within the sticky.
+  // The inner div carries the `sticky-text` class so the edit handler below
+  // can select it; existing inline styles remain unchanged.
   noteGroups
     .append('foreignObject')
     .attr('x', 14)
@@ -167,6 +192,7 @@ export function renderCanvas(container, notes, assignments = null, labels = null
     .attr('width', NOTE_W - 28)
     .attr('height', NOTE_H - 38)
     .append('xhtml:div')
+    .attr('class', 'sticky-text')
     .style('display', 'flex')
     .style('align-items', 'center')
     .style('justify-content', 'center')
@@ -260,6 +286,132 @@ export function renderCanvas(container, notes, assignments = null, labels = null
       .attr('stroke-width', 1.5);
   }
 
+  // ── Editing affordances ─────────────────────────────────────────────────────
+  // Hover toolbar (color + delete), in-place text edit on dblclick, and
+  // dblclick-on-empty-canvas to create a new note. Each is opt-in via callback.
+
+  const COLOR_KEYS = ['yellow', 'pink', 'blue', 'green', 'purple', 'orange', 'white'];
+
+  if (onNoteColorChange || onNoteDelete) {
+    // Toolbar foreignObject — appended after cluster dot so it paints on top.
+    const toolbar = noteGroups
+      .append('foreignObject')
+      .attr('x', 8)
+      .attr('y', 6)
+      .attr('width', NOTE_W - 16)
+      .attr('height', 24)
+      .style('overflow', 'visible');
+
+    const toolbarDiv = toolbar.append('xhtml:div')
+      .attr('class', 'sticky-toolbar')
+      .attr('data-mode', 'default');
+
+    if (typeof onNoteColorChange === 'function') {
+      toolbarDiv.append('xhtml:button')
+        .attr('class', 'sticky-tb-btn sticky-tb-color')
+        .attr('type', 'button')
+        .attr('aria-label', 'Change color')
+        .style('background', (d) => STICKY_COLORS[d.color] ?? STICKY_COLORS.default)
+        .on('mousedown', function (event) { event.stopPropagation(); })
+        .on('click', function (event) {
+          event.stopPropagation();
+          const tb = this.parentNode;
+          tb.dataset.mode = tb.dataset.mode === 'palette' ? 'default' : 'palette';
+        });
+
+      COLOR_KEYS.forEach((colorKey) => {
+        toolbarDiv.append('xhtml:button')
+          .attr('class', 'sticky-tb-btn sticky-tb-swatch')
+          .attr('type', 'button')
+          .attr('aria-label', `Set color to ${colorKey}`)
+          .attr('data-color', colorKey)
+          .style('background', STICKY_COLORS[colorKey])
+          .on('mousedown', function (event) { event.stopPropagation(); })
+          .on('click', function (event, d) {
+            event.stopPropagation();
+            this.parentNode.dataset.mode = 'default';
+            onNoteColorChange(d.id, colorKey);
+          });
+      });
+    }
+
+    if (typeof onNoteDelete === 'function') {
+      toolbarDiv.append('xhtml:button')
+        .attr('class', 'sticky-tb-btn sticky-tb-delete')
+        .attr('type', 'button')
+        .attr('aria-label', 'Delete note')
+        .text('×')
+        .on('mousedown', function (event) { event.stopPropagation(); })
+        .on('click', function (event, d) {
+          event.stopPropagation();
+          onNoteDelete(d.id);
+        });
+    }
+
+    // Collapse palette when the user moves off the note.
+    noteGroups.on('mouseleave.toolbar', function () {
+      const tb = this.querySelector('.sticky-toolbar');
+      if (tb && tb.dataset.mode === 'palette') tb.dataset.mode = 'default';
+    });
+  }
+
+  // Text edit on double-click of the text body.
+  function enterEditMode(textEl, d) {
+    const noteG = textEl.closest('g.sticky');
+    if (!noteG) return;
+    noteG.dataset.editing = 'true';
+    textEl.contentEditable = 'plaintext-only';
+    textEl.focus();
+
+    const range = document.createRange();
+    range.selectNodeContents(textEl);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    const oldText = d.text;
+    const cleanup = () => {
+      textEl.contentEditable = 'false';
+      noteG.dataset.editing = 'false';
+      textEl.removeEventListener('blur', onBlur);
+      textEl.removeEventListener('keydown', onKeydown);
+    };
+    const commit = () => {
+      const newText = textEl.textContent.trim();
+      cleanup();
+      if (!newText) { textEl.textContent = oldText; return; }
+      if (newText !== oldText) onNoteEdit(d.id, newText);
+    };
+    const cancel = () => { cleanup(); textEl.textContent = oldText; };
+
+    const onBlur = () => commit();
+    const onKeydown = (e) => {
+      if (e.key === 'Escape')         { e.preventDefault(); cancel(); textEl.blur(); }
+      else if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commit(); textEl.blur(); }
+    };
+    textEl.addEventListener('blur', onBlur);
+    textEl.addEventListener('keydown', onKeydown);
+  }
+
+  if (typeof onNoteEdit === 'function') {
+    noteGroups.select('.sticky-text').on('dblclick', function (event, d) {
+      event.stopPropagation();
+      enterEditMode(this, d);
+    });
+  }
+
+  // Double-click on empty canvas → create a new note centred on the click.
+  if (typeof onNoteCreate === 'function') {
+    svg.on('dblclick', function (event) {
+      if (event.target.closest('g.sticky')) return;
+      const [sx, sy] = d3.pointer(event, g.node());
+      onNoteCreate({
+        x: Math.round(sx - NOTE_W / 2),
+        y: Math.round(sy - NOTE_H / 2),
+      });
+    });
+  }
+
   // ── Z-stack ordering & drag ──────────────────────────────────────────────────
   // Reorder note groups by z so a higher z paints on top of lower-z siblings.
   // The data array order is unchanged — assignments[i] still aligns with notes[i].
@@ -269,6 +421,13 @@ export function renderCanvas(container, notes, assignments = null, labels = null
     let didMove = false;
 
     const drag = d3.drag()
+      .filter(function (event) {
+        // Don't start a drag while the user is editing this note's text,
+        // or when the pointer-down lands on the toolbar buttons.
+        if (this.dataset.editing === 'true') return false;
+        if (event.target.closest('.sticky-toolbar')) return false;
+        return event.button === 0;
+      })
       .on('start', function () {
         didMove = false;
         d3.select(this).raise().style('cursor', 'grabbing');
@@ -366,6 +525,16 @@ export function renderCanvas(container, notes, assignments = null, labels = null
           .attr('transform', scaleOut)
           .attr('fill-opacity', 0.07)
           .attr('stroke-opacity', 0.30);
+    });
+  }
+
+  // Auto-enter edit mode for a freshly-created note. requestAnimationFrame
+  // gives the browser one paint to settle the foreignObject before focus.
+  if (autoEditNoteId && typeof onNoteEdit === 'function') {
+    noteGroups.each(function (d) {
+      if (d.id !== autoEditNoteId) return;
+      const textEl = this.querySelector('.sticky-text');
+      if (textEl) requestAnimationFrame(() => enterEditMode(textEl, d));
     });
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -98,11 +98,13 @@ function applyHullVisibility() {
 
 hullToggle.addEventListener('change', applyHullVisibility);
 
-// ─── Drag → dirty (no auto-save in this app) ──────────────────────
-// Drag updates positions in memory only. Persistence happens when the
-// user clicks Download. The `dirty` flag drives the Download button
-// styling and a beforeunload warning so unsaved changes aren't lost
-// to a stray tab close.
+// ─── Edit & drag → dirty (no auto-save in this app) ──────────────
+// All canvas mutations (drag, text edit, color change, add, delete)
+// run through these handlers, mark the board `dirty`, and re-render
+// when needed. Persistence happens when the user clicks Download.
+// The `dirty` flag drives the Download button styling and a
+// beforeunload warning so unsaved changes aren't lost to a stray
+// tab close.
 
 function setDirty(flag) {
   if (dirty === flag) return;
@@ -118,20 +120,94 @@ window.addEventListener('beforeunload', (e) => {
   e.returnValue = '';
 });
 
+// Single source of truth for renderCanvas options. Pass `extra` to
+// override or extend (e.g. autoEditNoteId after a fresh create).
+function renderOptions(extra = {}) {
+  return {
+    onDragEnd:         handleNoteDragEnd,
+    onNoteEdit:        handleNoteEdit,
+    onNoteDelete:      handleNoteDelete,
+    onNoteColorChange: handleNoteColorChange,
+    onNoteCreate:      handleNoteCreate,
+    ...extra,
+  };
+}
+
+function reRenderCanvas(extra = {}) {
+  if (assignments.length > 0) {
+    const labels = clusters.map((c) => c.label);
+    renderCanvas(canvasContainer, notes, assignments, labels, renderOptions(extra));
+    applyHullVisibility();
+  } else {
+    renderCanvas(canvasContainer, notes, null, null, renderOptions(extra));
+  }
+}
+
+// Drops cluster state. Adding/deleting notes shifts indices, which would
+// misalign assignments[i] with notes[i] and stale the embeddings cache.
+function invalidateClustering() {
+  if (assignments.length === 0) return;
+  assignments       = [];
+  clusters          = [];
+  embeddingsReduced = [];
+  invalidateSemanticView();
+  viewToggle.classList.add('hidden');
+  hullToggleWrap.classList.add('hidden');
+  showView('canvas');
+}
+
 function handleNoteDragEnd(id, { x, y, z }) {
   const i = noteIdToIdx.get(id);
   if (i === undefined) return;
   notes[i].x = x;
   notes[i].y = y;
   notes[i].z = z;
-
-  if (assignments.length > 0) {
-    const labels = clusters.map((c) => c.label);
-    renderCanvas(canvasContainer, notes, assignments, labels, { onDragEnd: handleNoteDragEnd });
-    applyHullVisibility();
-  }
-
+  // If hulls are present, re-render to recompute around the new position.
+  if (assignments.length > 0) reRenderCanvas();
   setDirty(true);
+}
+
+function handleNoteEdit(id, newText) {
+  const i = noteIdToIdx.get(id);
+  if (i === undefined) return;
+  notes[i].text = newText;
+  setDirty(true);
+  // Text changes don't shift indices — assignments stay structurally valid.
+  // Embeddings are stale though; the user can re-cluster for updated themes.
+}
+
+function handleNoteColorChange(id, color) {
+  const i = noteIdToIdx.get(id);
+  if (i === undefined) return;
+  notes[i].color = color;
+  setDirty(true);
+  reRenderCanvas();
+}
+
+function handleNoteDelete(id) {
+  const i = noteIdToIdx.get(id);
+  if (i === undefined) return;
+  notes.splice(i, 1);
+  noteIdToIdx = new Map(notes.map((n, idx) => [n.id, idx]));
+  invalidateClustering();
+  setDirty(true);
+  reRenderCanvas();
+}
+
+function handleNoteCreate({ x, y }) {
+  const newNote = {
+    id:     `note_${crypto.randomUUID().slice(0, 8)}`,
+    text:   'New note',
+    x, y,
+    author: 'you',
+    color:  'yellow',
+    z:      notes.reduce((m, n) => (n.z > m ? n.z : m), 0) + 1,
+  };
+  notes.push(newNote);
+  noteIdToIdx.set(newNote.id, notes.length - 1);
+  invalidateClustering();
+  setDirty(true);
+  reRenderCanvas({ autoEditNoteId: newNote.id });
 }
 
 // ─── Cluster action ───────────────────────────────────────────────
@@ -178,7 +254,7 @@ btnClusterAction.addEventListener('click', async () => {
 
     hideProgress();
 
-    renderCanvas(canvasContainer, notes, assignments, labels, { onDragEnd: handleNoteDragEnd });
+    renderCanvas(canvasContainer, notes, assignments, labels, renderOptions());
     clusterViewApi = renderClusterView(clusterContainer, notes, assignments, clusters);
 
     applyHullVisibility();
@@ -224,7 +300,7 @@ function loadBoard({ data, name }) {
   canvasView.classList.remove('hidden');
   btnClusterAction.disabled = false;
   btnDownload.classList.remove('hidden');
-  renderCanvas(canvasContainer, notes, null, null, { onDragEnd: handleNoteDragEnd });
+  renderCanvas(canvasContainer, notes, null, null, renderOptions());
 }
 
 async function handleImport() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -318,6 +318,84 @@ body {
   border: 1.5px solid rgba(0,0,0,0.2);
 }
 
+/* ─── Sticky toolbar (color + delete + palette swatches) ───────── */
+.sticky-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  pointer-events: none; /* let drag/dblclick fall through when hidden */
+}
+
+/* Reveal on hover; stay revealed while in palette mode regardless of hover. */
+.sticky:hover .sticky-toolbar,
+.sticky-toolbar[data-mode="palette"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.sticky[data-editing="true"] .sticky-toolbar {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+.sticky-tb-btn {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0, 0, 0, 0.20);
+  background: white;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.55);
+  transition: transform 0.1s, border-color 0.1s, color 0.1s;
+}
+
+.sticky-tb-btn:hover { transform: scale(1.1); border-color: rgba(0, 0, 0, 0.45); }
+.sticky-tb-btn:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 1px; }
+
+.sticky-tb-delete:hover { color: #b91c1c; border-color: #b91c1c; } /* 5.9:1 on white */
+
+/* Default mode: color + delete shown, swatches hidden. */
+.sticky-toolbar[data-mode="default"] .sticky-tb-swatch { display: none; }
+
+/* Palette mode: swatches shown, color/delete hidden. */
+.sticky-toolbar[data-mode="palette"] .sticky-tb-color,
+.sticky-toolbar[data-mode="palette"] .sticky-tb-delete { display: none; }
+
+.sticky-tb-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0, 0, 0, 0.20);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: transform 0.1s, border-color 0.1s;
+}
+
+.sticky-tb-swatch:hover { transform: scale(1.15); border-color: rgba(0, 0, 0, 0.50); }
+
+/* Editing: outline the text body and let it scroll if needed. */
+.sticky[data-editing="true"] .sticky-text {
+  cursor: text;
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  border-radius: 4px;
+  /* Override the inline centering so the caret behaves predictably. */
+  text-align: left !important;
+  align-items: flex-start !important;
+  overflow: auto !important;
+}
+
+.sticky-text:focus { outline: 2px solid var(--color-primary); outline-offset: -2px; }
+
 /* ─── Cluster tooltip ──────────────────────────────────────────── */
 .cluster-tooltip {
   position: absolute;


### PR DESCRIPTION
Closes [#2](https://github.com/vmorais17/local-semantics-canvas/issues/2).

## What changed

All four edit affordances live entirely on the canvas — no header buttons, no modals.

| Gesture | Action |
|---|---|
| Hover note | Top-left toolbar appears: [color] [×] |
| Click [color] | Toolbar transforms inline into 7 swatches; pick to recolor |
| Click [×] | Delete the note |
| Double-click text body | Edit in place. Enter / blur commits, Esc reverts, blank reverts |
| Double-click empty canvas | Create a new yellow \"you\" note at the click position, auto-enters edit mode |

All four mutations route through `main.js`, set `dirty`, and respect the existing **Download** / `beforeunload` contract from [#13](https://github.com/vmorais17/local-semantics-canvas/pull/13). The on-disk schema is unchanged.

## Reviewer notes

- **Cluster invalidation rule**: adding or deleting a note shifts indices, so `assignments[i]` would no longer line up with `notes[i]` — those mutations drop the cluster state and hide the view-toggle / hull-toggle. Text and color edits leave clusters intact (indices stable), but embeddings are stale; user can re-cluster for refreshed themes.
- **Drag and create-on-dblclick are suppressed while editing** — `d3.drag().filter` checks `data-editing` on the note group, and the SVG dblclick handler ignores events whose target is inside any `g.sticky`. Click events on toolbar buttons stop propagation so drag doesn't pick them up.
- **Auto-edit after create**: `renderCanvas` accepts a new `autoEditNoteId` option. After `handleNoteCreate` re-renders, the matching note enters edit mode on the next animation frame (gives the foreignObject one paint to settle before `focus()`).
- **Empty-text revert**: enforced in canvas-view, not main. The handler doesn't fire when the user clears the text — original is restored locally.
- **`contentEditable = 'plaintext-only'`** is Chromium/WebKit. Firefox falls back to rich-text contenteditable; behaviour is functional but pasted formatting won't be stripped. Acceptable for a Brave-default-flags target.
- **Hardcoded defaults for new notes**: `text: 'New note'`, `author: 'you'`, `color: 'yellow'`, `z = max(z) + 1`. The id is `note_<8-char uuid suffix>`.
- **a11y**: each toolbar button has `aria-label`; the contenteditable text is keyboard-reachable via Tab once focused. Touch / keyboard alternatives for drag and create remain a known gap (tracked separately from this issue).

## Test plan

- [x] `npm run build` ✓
- [x] `node --check` on canvas-view + main ✓
- [x] Dev server: `/` and `/data/sticky_notes.json` are 200; new symbols (`sticky-toolbar`, `sticky-tb-*`, `enterEditMode`, `onNoteEdit`, `onNoteCreate`) appear in served JS
- [ ] Manual on Brave (default flags):
  - [x] Start from starter → hover any note → toolbar fades in
  - [x] Click color circle → 7 swatches replace it; click one → note recolours, swatches collapse
  - [ ] Click × → note disappears, view-toggle / hull-toggle hide if they were shown
  - [x] Double-click text → inline edit, Enter saves, Esc reverts, blank reverts
  - [x] Double-click empty canvas → new note appears, auto-enters edit, type to replace placeholder
  - [ ] Drag a note → no edit fires; drag still saves on release; Download border lights up
  - [ ] Find Themes → drag inside a cluster → hull recomputes; delete a note → clusters drop and view-toggle hides
  - [ ] Download → file contains the new note(s) with edited text / color / position; reload → import → identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)